### PR TITLE
Update Snapdrop client to be proxy friendly.

### DIFF
--- a/client/scripts/network.js
+++ b/client/scripts/network.js
@@ -58,7 +58,7 @@ class ServerConnection {
         // hack to detect if deployment or development environment
         const protocol = location.protocol.startsWith('https') ? 'wss' : 'ws';
         const webrtc = window.isRtcSupported ? '/webrtc' : '/fallback';
-        const url = protocol + '://' + location.host + '/server' + webrtc;
+        const url = protocol + '://' + location.host + location.pathname + '/server' + webrtc;
         return url;
     }
 


### PR DESCRIPTION
Adds location.pathname to the socket location, this is needed to make snapdrop proxiable which allows it to be used as Home Assistant Addon.